### PR TITLE
Dynamic type support

### DIFF
--- a/imink/Shared/Utils/ConvenientColors.swift
+++ b/imink/Shared/Utils/ConvenientColors.swift
@@ -27,6 +27,10 @@ extension Color {
         Color(.systemGray5)
     }
     
+    static var label: Color {
+        Color(.label)
+    }
+    
     static var secondaryLabel: Color {
         Color(.secondaryLabel)
     }

--- a/imink/Shared/ViewModifiers/FontModifier.swift
+++ b/imink/Shared/ViewModifiers/FontModifier.swift
@@ -46,36 +46,37 @@ struct SP2FontModifier: ViewModifier {
 
 struct FontModifiers_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
-            Text("System Text")
-                .font(.system(size: 24))
-            
-            Text("SplaFont1, S")
-                .sp1Font(size: 24, color: Color.label)
-                .environment(\.sizeCategory, ContentSizeCategory.small)
+        VStack {
+            Group {
+                Text("System Text")
+                    .font(.system(size: 24))
+                
+                Text("SplaFont1, S")
+                    .sp1Font(size: 24, color: Color.label)
+                    .environment(\.sizeCategory, ContentSizeCategory.small)
 
-            Text("SplaFont1, XXL")
-                .sp1Font(size: 24, color: Color.label)
-                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
-            
-            Text("SplaFont1,\nNewLine")
-                .sp1Font(size: 24, color: Color.label, lineLimit: nil)
-                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
-            
-            Text("SplaFont2, S")
-                .sp2Font(size: 24, color: Color.label)
-                .environment(\.sizeCategory, ContentSizeCategory.small)
+                Text("SplaFont1, XXL")
+                    .sp1Font(size: 24, color: Color.label)
+                    .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+                
+                Text("SplaFont1,\nNewLine")
+                    .sp1Font(size: 24, color: Color.label, lineLimit: nil)
+                    .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+                
+                Text("SplaFont2, S")
+                    .sp2Font(size: 24, color: Color.label)
+                    .environment(\.sizeCategory, ContentSizeCategory.small)
 
-            Text("SplaFont2, XXL")
-                .sp2Font(size: 24, color: Color.label)
-                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
-            
-            Text("SplaFont2,\nNewLine")
-                .sp2Font(size: 24, color: Color.label, lineLimit: nil)
-                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+                Text("SplaFont2, XXL")
+                    .sp2Font(size: 24, color: Color.label)
+                    .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+                
+                Text("SplaFont2,\nNewLine")
+                    .sp2Font(size: 24, color: Color.label, lineLimit: nil)
+                    .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+            }
+            .border(Color.blue)
+            .padding(4)
         }
-        .border(Color.blue)
-        .previewLayout(.sizeThatFits)
-        .padding()
     }
 }

--- a/imink/Shared/ViewModifiers/FontModifier.swift
+++ b/imink/Shared/ViewModifiers/FontModifier.swift
@@ -7,60 +7,75 @@
 
 import SwiftUI
 
-struct FontModifiers_Previews: PreviewProvider {
-    static var previews: some View {
-        VStack {
-            Text("Hello, World!").sp1Font(size: 40)
-            Text("Hello, World!").sp2Font(size: 40)
-        }
-    }
-}
-
-extension Text {
-    func sp1Font(size: CGFloat = 12, color: Color = .white, lineLimit: Int = 1) -> some View {
+extension View {
+    func sp1Font(size: CGFloat = 12, color: Color = .white, lineLimit: Int? = 1) -> some View {
         self.modifier(SP1FontModifier(size: size, color: color, lineLimit: lineLimit))
     }
     
-    func sp2Font(size: CGFloat = 12, color: Color = .white, lineLimit: Int = 1) -> some View {
+    func sp2Font(size: CGFloat = 12, color: Color = .white, lineLimit: Int? = 1) -> some View {
         self.modifier(SP2FontModifier(size: size, color: color, lineLimit: lineLimit))
-    }
-}
-
-extension TextField {
-    func sp1Font(size: CGFloat = 12, color: Color = .white, lineLimit: Int = 1) -> some View {
-        self.modifier(SP1FontModifier(size: size, color: color, lineLimit: lineLimit))
-    }
-    
-    func sp2Font(size: CGFloat = 12, color: Color = .white, lineLimit: Int = 1) -> some View {
-        self.modifier(SP2FontModifier(size: size, color: color, lineLimit: lineLimit))
-
     }
 }
 
 struct SP1FontModifier: ViewModifier {
-    var size: CGFloat
+    @ScaledMetric var size: CGFloat
     var color: Color
-    var lineLimit: Int = 1
+    var lineLimit: Int?
     
     func body(content: Content) -> some View {
         content
             .font(.custom(AppTheme.spFontName, size: size))
             .foregroundColor(color)
             .lineLimit(lineLimit)
-            .frame(height: lineLimit == 1 ? size : .infinity)
+            .frame(height: lineLimit == 1 ? size * 1.3: nil)
     }
 }
 
 struct SP2FontModifier: ViewModifier {
     var size: CGFloat
     var color: Color
-    var lineLimit: Int = 1
+    var lineLimit: Int?
     
     func body(content: Content) -> some View {
         content
             .font(.custom(AppTheme.sp2FontName, size: size))
             .foregroundColor(color)
             .lineLimit(lineLimit)
-            .frame(height: lineLimit == 1 ? size : .infinity)
+    }
+}
+
+struct FontModifiers_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            Text("System Text")
+                .font(.system(size: 24))
+            
+            Text("SplaFont1, S")
+                .sp1Font(size: 24, color: Color.label)
+                .environment(\.sizeCategory, ContentSizeCategory.small)
+
+            Text("SplaFont1, XXL")
+                .sp1Font(size: 24, color: Color.label)
+                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+            
+            Text("SplaFont1,\nNewLine")
+                .sp1Font(size: 24, color: Color.label, lineLimit: nil)
+                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+            
+            Text("SplaFont2, S")
+                .sp2Font(size: 24, color: Color.label)
+                .environment(\.sizeCategory, ContentSizeCategory.small)
+
+            Text("SplaFont2, XXL")
+                .sp2Font(size: 24, color: Color.label)
+                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+            
+            Text("SplaFont2,\nNewLine")
+                .sp2Font(size: 24, color: Color.label, lineLimit: nil)
+                .environment(\.sizeCategory, ContentSizeCategory.extraExtraLarge)
+        }
+        .border(Color.blue)
+        .previewLayout(.sizeThatFits)
+        .padding()
     }
 }


### PR DESCRIPTION
有些用户（包括我）觉得应用里字体太小了，并且很多地方的文字是写死 frame size 的，导致调整 Dynamic Type 时没法正常显示，所以想来对这方面做一点微小的贡献。第一步先支持一下 Dynamic Type，之后再在各个地方调整具体使用。

效果（蓝框表示尺寸）：
<img src="https://user-images.githubusercontent.com/11924267/115132706-656ca400-a03d-11eb-9b55-39b2e9e42789.jpg" width="250">

## Spla1Font
关于文字大小，原字体的行高有问题，所以只能支持一行的情况，多行只能让它保持原本过大的尺寸。
一行的情况下追加了 `@ScaledMetric` 来让字体尺寸保持正常且支持 Dynamic Type。

## Spla2Font
原字体行高没问题，所以没必要用 `.frame` 限制尺寸

## 其他更改
- 把`.sp1/2Font` 写在 `View` 下
鉴于原来的 `.font` 就是通用的，没必要专门写在 `Text` & `TextField` 下。

- 追加了 `Color.label`

- `lineLimit` 改成 optional ，和原函数保持一致。